### PR TITLE
Update RAM requirement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ C++ is a unique language for its ability to write high-level abstractions while 
 ### Hardware Requirements
 For an optimal student experience, we recommend the following hardware configuration:
 * **Processor**: Intel Core i3 or equivalent
-* **Memory**: 40GB RAM
+* **Memory**: 4GB RAM
 * **Storage**: 10 GB available space
 * An Internet connection
 


### PR DESCRIPTION
I was reading the `README.md` file and noticed it said you require 40GB of RAM. Given that very few people have above 8GB and a select few have 32GB let alone 40GB of RAM 😄 and that this course is an intro to C++ I believe this to be a typo, if this is the case this pull request fixes it.